### PR TITLE
Patch v0.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.nullicorn</groupId>
     <artifactId>Nedit</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
@@ -225,7 +225,7 @@ public class NBTCompound extends HashMap<String, Object> {
             if (i != 0) {
                 sb.append(",");
             }
-            sb.append(tag.getKey());
+            sb.append(tag.getKey().isEmpty() ? "\"\"" : tag.getKey());
             sb.append(":");
             sb.append(tagToString(tag.getValue()));
             i++;

--- a/src/main/java/me/nullicorn/nedit/type/NBTList.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTList.java
@@ -3,7 +3,6 @@ package me.nullicorn.nedit.type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
-import javax.xml.bind.TypeConstraintException;
 import lombok.Getter;
 
 /**
@@ -58,7 +57,7 @@ public class NBTList extends ArrayList<Object> {
      */
     private void checkType(Object o) {
         if (!o.getClass().equals(contentType.getClazz())) {
-            throw new TypeConstraintException(String.format("Expected %s but found %s", contentType.getClazz(), o.getClass()));
+            throw new IllegalArgumentException(String.format("Expected %s but found %s", contentType.getClazz(), o.getClass()));
         }
     }
 


### PR DESCRIPTION
- Fixed `NoClassDefFoundError` caused by JAXB import
- Use empty quotes in `NBTCompound.toString()` when tag name is empty