### PR TITLE
Update v1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.nullicorn</groupId>
     <artifactId>Nedit</artifactId>
-    <version>0.1.0</version>
+    <version>1.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/nullicorn/nedit/NBTInputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTInputStream.java
@@ -152,12 +152,13 @@ public class NBTInputStream extends DataInputStream {
             throw new IndexOutOfBoundsException("TAG_Byte_Array array was prefixed with a negative length");
         }
 
-        byte[] byteArray = new byte[length];
-        for (int i = 0; i < byteArray.length; i++) {
-            byteArray[i] = readByte();
+        byte[] bytes = new byte[length];
+        int bytesRead = read(bytes);
+        if (bytesRead < bytes.length) {
+            throw new IndexOutOfBoundsException("Unable to fully read TAG_Byte_Array");
         }
 
-        return byteArray;
+        return bytes;
     }
 
     /**

--- a/src/main/java/me/nullicorn/nedit/NBTInputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTInputStream.java
@@ -153,10 +153,7 @@ public class NBTInputStream extends DataInputStream {
         }
 
         byte[] bytes = new byte[length];
-        int bytesRead = read(bytes);
-        if (bytesRead < bytes.length) {
-            throw new IndexOutOfBoundsException("Unable to fully read TAG_Byte_Array");
-        }
+        readFully(bytes);
 
         return bytes;
     }

--- a/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
@@ -91,15 +91,15 @@ public class NBTOutputStream extends DataOutputStream {
                 return;
 
             case BYTE_ARRAY:
-                writeByteArray((Byte[]) value);
+                writeByteArray((byte[]) value);
                 return;
 
             case INT_ARRAY:
-                writeIntArray((Integer[]) value);
+                writeIntArray((int[]) value);
                 return;
 
             case LONG_ARRAY:
-                writeLongArray((Long[]) value);
+                writeLongArray((long[]) value);
         }
     }
 
@@ -141,7 +141,7 @@ public class NBTOutputStream extends DataOutputStream {
      *
      * @throws IOException If the value could not be written
      */
-    public void writeLongArray(Long[] longs) throws IOException {
+    public void writeLongArray(long[] longs) throws IOException {
         if (longs == null) {
             writeInt(0); // Length of zero
             return;
@@ -158,7 +158,7 @@ public class NBTOutputStream extends DataOutputStream {
      *
      * @throws IOException If the value could not be written
      */
-    public void writeIntArray(Integer[] ints) throws IOException {
+    public void writeIntArray(int[] ints) throws IOException {
         if (ints == null) {
             writeInt(0); // Length of zero
             return;
@@ -175,7 +175,7 @@ public class NBTOutputStream extends DataOutputStream {
      *
      * @throws IOException If the value could not be written
      */
-    public void writeByteArray(Byte[] bytes) throws IOException {
+    public void writeByteArray(byte[] bytes) throws IOException {
         if (bytes == null) {
             writeInt(0); // Length of zero
             return;
@@ -197,7 +197,7 @@ public class NBTOutputStream extends DataOutputStream {
             writeInt(0); // Length of zero
             return;
         }
-        
+
         byte[] strBytes = value.getBytes(StandardCharsets.UTF_8);
         writeUnsignedShort(strBytes.length);
         write(strBytes);

--- a/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
@@ -103,10 +103,10 @@ public class NBTCompound extends HashMap<String, Object> {
      * @see #get(String)
      */
     @Nullable
-    public Long[] getLongArray(String key) {
+    public long[] getLongArray(String key) {
         Object result = get(key);
-        return result instanceof Long[]
-            ? (Long[]) result
+        return result instanceof long[]
+            ? (long[]) result
             : null;
     }
 
@@ -116,10 +116,10 @@ public class NBTCompound extends HashMap<String, Object> {
      * @see #get(String)
      */
     @Nullable
-    public Integer[] getIntArray(String key) {
+    public int[] getIntArray(String key) {
         Object result = get(key);
-        return result instanceof Integer[]
-            ? (Integer[]) result
+        return result instanceof int[]
+            ? (int[]) result
             : null;
     }
 
@@ -129,10 +129,10 @@ public class NBTCompound extends HashMap<String, Object> {
      * @see #get(String)
      */
     @Nullable
-    public Byte[] getByteArray(String key) {
+    public byte[] getByteArray(String key) {
         Object result = get(key);
-        return result instanceof Byte[]
-            ? (Byte[]) result
+        return result instanceof byte[]
+            ? (byte[]) result
             : null;
     }
 
@@ -257,7 +257,7 @@ public class NBTCompound extends HashMap<String, Object> {
             case DOUBLE:
                 return doubleToString((Double) value);
             case BYTE_ARRAY:
-                return byteArrayToString((Byte[]) value);
+                return byteArrayToString((byte[]) value);
             case STRING:
                 return stringTagToString((String) value);
             case LIST:
@@ -265,9 +265,9 @@ public class NBTCompound extends HashMap<String, Object> {
             case COMPOUND:
                 return value.toString();
             case INT_ARRAY:
-                return intArrayToString((Integer[]) value);
+                return intArrayToString((int[]) value);
             case LONG_ARRAY:
-                return longArrayToString((Long[]) value);
+                return longArrayToString((long[]) value);
             default:
                 return "";
         }
@@ -297,11 +297,11 @@ public class NBTCompound extends HashMap<String, Object> {
         return value + "d";
     }
 
-    private static String byteArrayToString(Byte[] value) {
+    private static String byteArrayToString(byte[] value) {
         StringBuilder sb = new StringBuilder();
         sb.append("[B;");
         for (int i = 0; i < value.length; i++) {
-            sb.append(value[i] != null ? value[i] : 0);
+            sb.append(value[i]);
             if (i < value.length - 1) {
                 sb.append(",");
             }
@@ -327,11 +327,11 @@ public class NBTCompound extends HashMap<String, Object> {
         return sb.toString();
     }
 
-    private static String intArrayToString(Integer[] value) {
+    private static String intArrayToString(int[] value) {
         StringBuilder sb = new StringBuilder();
         sb.append("[I;");
         for (int i = 0; i < value.length; i++) {
-            sb.append(value[i] != null ? value[i] : 0);
+            sb.append(value[i]);
             if (i < value.length - 1) {
                 sb.append(",");
             }
@@ -340,11 +340,11 @@ public class NBTCompound extends HashMap<String, Object> {
         return sb.toString();
     }
 
-    private static String longArrayToString(Long[] value) {
+    private static String longArrayToString(long[] value) {
         StringBuilder sb = new StringBuilder();
         sb.append("[L;");
         for (int i = 0; i < value.length; i++) {
-            sb.append(value[i] != null ? value[i] : 0);
+            sb.append(value[i]);
             if (i < value.length - 1) {
                 sb.append(",");
             }

--- a/src/main/java/me/nullicorn/nedit/type/NBTList.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTList.java
@@ -119,25 +119,25 @@ public class NBTList extends ArrayList<Object> {
     /**
      * @throws IllegalStateException If this this list cannot contain byte array tags
      */
-    public Byte[] getByteArray(int index) {
+    public byte[] getByteArray(int index) {
         checkGetType(TagType.BYTE_ARRAY);
-        return (Byte[]) get(index);
+        return (byte[]) get(index);
     }
 
     /**
      * @throws IllegalStateException If this this list cannot contain integer array tags
      */
-    public Integer[] getIntArray(int index) {
+    public int[] getIntArray(int index) {
         checkGetType(TagType.INT_ARRAY);
-        return (Integer[]) get(index);
+        return (int[]) get(index);
     }
 
     /**
      * @throws IllegalStateException If this this list cannot contain long array tags
      */
-    public Long[] getLongArray(int index) {
+    public long[] getLongArray(int index) {
         checkGetType(TagType.LONG_ARRAY);
-        return (Long[]) get(index);
+        return (long[]) get(index);
     }
 
     /**
@@ -237,7 +237,7 @@ public class NBTList extends ArrayList<Object> {
      *
      * @throws IllegalStateException If this this list cannot contain byte array tags
      */
-    public void forEachByteArray(Consumer<Byte[]> action) {
+    public void forEachByteArray(Consumer<byte[]> action) {
         checkGetType(TagType.BYTE_ARRAY);
         forEachOfType(action);
     }
@@ -247,7 +247,7 @@ public class NBTList extends ArrayList<Object> {
      *
      * @throws IllegalStateException If this this list cannot contain integer array tags
      */
-    public void forEachIntArray(Consumer<Integer[]> action) {
+    public void forEachIntArray(Consumer<int[]> action) {
         checkGetType(TagType.INT_ARRAY);
         forEachOfType(action);
     }
@@ -257,7 +257,7 @@ public class NBTList extends ArrayList<Object> {
      *
      * @throws IllegalStateException If this this list cannot contain long array tags
      */
-    public void forEachLongArray(Consumer<Long[]> action) {
+    public void forEachLongArray(Consumer<long[]> action) {
         checkGetType(TagType.LONG_ARRAY);
         forEachOfType(action);
     }

--- a/src/main/java/me/nullicorn/nedit/type/TagType.java
+++ b/src/main/java/me/nullicorn/nedit/type/TagType.java
@@ -49,7 +49,7 @@ public enum TagType {
     /**
      * Represents a length-prefixed array of signed bytes
      */
-    BYTE_ARRAY(0x07, Byte[].class),
+    BYTE_ARRAY(0x07, byte[].class),
 
     /**
      * Represents a length-prefixed string of text
@@ -69,12 +69,12 @@ public enum TagType {
     /**
      * Represents a length-prefixed array of signed integers
      */
-    INT_ARRAY(0x0B, Integer[].class),
+    INT_ARRAY(0x0B, int[].class),
 
     /**
      * Represents a length-prefixed array of signed long integers
      */
-    LONG_ARRAY(0x0C, Long[].class);
+    LONG_ARRAY(0x0C, long[].class);
 
     // An unmodifiable map of IDs to types (for reverse search)
     private static final Map<Integer, TagType> values;
@@ -141,7 +141,7 @@ public enum TagType {
         } else if (obj instanceof Double) {
             return DOUBLE;
 
-        } else if (obj instanceof Byte[]) {
+        } else if (obj instanceof byte[]) {
             return BYTE_ARRAY;
 
         } else if (obj instanceof String) {
@@ -153,10 +153,10 @@ public enum TagType {
         } else if (obj instanceof NBTCompound) {
             return COMPOUND;
 
-        } else if (obj instanceof Integer[]) {
+        } else if (obj instanceof int[]) {
             return INT_ARRAY;
 
-        } else if (obj instanceof Long[]) {
+        } else if (obj instanceof long[]) {
             return LONG_ARRAY;
 
         } else {


### PR DESCRIPTION
- Use only primitive arrays for byte[], int[], and long[]
- Slightly optimize `NBTInputStream#readByteArray()`