### PR TITLE
Update v1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.nullicorn</groupId>
     <artifactId>Nedit</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
@@ -27,7 +27,7 @@ public class NBTOutputStream extends DataOutputStream {
      * @throws IOException If the compound could not be written
      */
     public void writeFully(NBTCompound compound) throws IOException {
-        writeCompound(compound);
+        writeCompound(compound, false);
         if (out instanceof GZIPOutputStream) {
             ((GZIPOutputStream) out).finish();
         }
@@ -104,17 +104,31 @@ public class NBTOutputStream extends DataOutputStream {
     }
 
     /**
-     * Write a compound tag to the stream
+     * Same as {@link #writeCompound(NBTCompound, boolean)}, but with {@code close} set to {@literal
+     * true}.
      *
-     * @throws IOException If the compound could not be written
+     * @see #writeCompound(NBTCompound, boolean)
      */
     public void writeCompound(NBTCompound compound) throws IOException {
+        writeCompound(compound, true);
+    }
+
+    /**
+     * Write a compound tag to the stream
+     *
+     * @param close Whether or not the compound should be closed via a {@link TagType#END}. This
+     *              should be true for any compound except the root.
+     * @throws IOException If the compound could not be written
+     */
+    public void writeCompound(NBTCompound compound, boolean close) throws IOException {
         for (Entry<String, Object> tag : compound.entrySet()) {
             writeTagType(TagType.fromObject(tag.getValue())); // Tag type
             writeString(tag.getKey()); // Tag name
             writeValue(tag.getValue()); // Tag value
         }
-        writeTagType(TagType.END);
+        if (close) {
+            writeTagType(TagType.END);
+        }
     }
 
     /**

--- a/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map.Entry;
 import java.util.zip.GZIPOutputStream;
+import me.nullicorn.nedit.exception.NBTSerializationException;
 import me.nullicorn.nedit.type.NBTCompound;
 import me.nullicorn.nedit.type.NBTList;
 import me.nullicorn.nedit.type.TagType;
@@ -56,50 +57,55 @@ public class NBTOutputStream extends DataOutputStream {
         switch (tagType) {
             case BYTE:
                 writeByte((Byte) value);
-                return;
+                break;
 
             case SHORT:
                 writeShort((Short) value);
-                return;
+                break;
 
             case INT:
                 writeInt((Integer) value);
-                return;
+                break;
 
             case LONG:
                 writeLong((Long) value);
-                return;
+                break;
 
             case FLOAT:
                 writeFloat((Float) value);
-                return;
+                break;
 
             case DOUBLE:
                 writeDouble((Double) value);
-                return;
+                break;
 
             case STRING:
                 writeString((String) value);
-                return;
+                break;
 
             case LIST:
                 writeList((NBTList) value);
-                return;
+                break;
 
             case COMPOUND:
                 writeCompound((NBTCompound) value);
-                return;
+                break;
 
             case BYTE_ARRAY:
                 writeByteArray((byte[]) value);
-                return;
+                break;
 
             case INT_ARRAY:
                 writeIntArray((int[]) value);
-                return;
+                break;
 
             case LONG_ARRAY:
                 writeLongArray((long[]) value);
+                break;
+
+            case END:
+                throw new NBTSerializationException(
+                    "Tag " + tagType + " cannot be written as a value");
         }
     }
 

--- a/src/main/java/me/nullicorn/nedit/SNBTReader.java
+++ b/src/main/java/me/nullicorn/nedit/SNBTReader.java
@@ -1,0 +1,388 @@
+package me.nullicorn.nedit;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NonNull;
+import me.nullicorn.nedit.exception.NBTParseException;
+import me.nullicorn.nedit.type.NBTCompound;
+import me.nullicorn.nedit.type.NBTList;
+import me.nullicorn.nedit.type.TagType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A utility class for reading stringified NBT data (SNBT)
+ * <p>
+ * For converting NBT data in base64 string format, see {@link NBTReader#readBase64(String)}
+ *
+ * @author Nullicorn
+ */
+public final class SNBTReader {
+
+    private static final char COMPOUND_START = '{';
+    private static final char COMPOUND_END   = '}';
+
+    private static final char ENTRY_VALUE_INDICATOR = ':';
+    private static final char ENTRY_SEPARATOR       = ','; // Used in compounds, lists, and arrays
+
+    private static final char ARRAY_START          = '['; // Used in arrays and lists
+    private static final char ARRAY_END            = ']'; // Used in arrays and lists
+    private static final char ARRAY_TYPE_INDICATOR = ';';
+
+    private static final char STRING_DELIMITER_1 = '\"';
+    private static final char STRING_DELIMITER_2 = '\'';
+    private static final char STRING_ESCAPE      = '\\';
+
+    private static final String BYTE_PATTERN   = "^[+-]?\\d+[Bb]$";
+    private static final String SHORT_PATTERN  = "^[+-]?\\d+[Ss]$";
+    private static final String INT_PATTERN    = "^[+-]?\\d+$";
+    private static final String LONG_PATTERN   = "^[+-]?\\d+[Ll]$";
+    private static final String FLOAT_PATTERN  = "^[+-]?[0-9]*\\.?[0-9]+[Ff]$";
+    private static final String DOUBLE_PATTERN = "^[+-]?[0-9]*\\.?[0-9]+[Dd]$";
+
+    /**
+     * Used to find and delete suffixes from numeric literals.
+     */
+    private static final String LITERAL_SUFFIX_PATTERN = "[BbDdFfLlSs]$";
+
+    /**
+     * All characters that can be used in strings without quotation marks (including tag names).
+     */
+    private static final String VALID_UNQUOTED_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-+_.";
+
+    /**
+     * Read an NBT value from an SNBT (stringified NBT) string.
+     * <p>
+     * If you are sure that your data will be an {@link NBTCompound} or {@link NBTList}, you may use
+     * {@link #readCompound(String)} and {@link #readList(String)} respectively. Unlike those
+     * methods, this one will directly parse and return SNBT literals (e.g. 1b, 12.34F, "Hello
+     * World", 450s, etc) and array types.
+     *
+     * @param snbt The text to parse into NBT
+     * @return The parsed NBT value (type will vary)
+     * @throws IOException If the input string cannot be read or is not valid SNBT
+     */
+    @NotNull
+    public static Object read(@NotNull String snbt) throws IOException {
+        return read(new StringReader(snbt.trim()));
+    }
+
+    /**
+     * Read an NBT compound from an SNBT (stringified NBT) string.
+     *
+     * @param snbt The text to parse into NBT
+     * @return The parsed NBT compound
+     * @throws IOException If the input string cannot be read or is not a valid SNBT compound
+     */
+    @NotNull
+    public static NBTCompound readCompound(@NotNull String snbt) throws IOException {
+        return readCompound(new StringReader(snbt.trim()));
+    }
+
+    /**
+     * Read an NBT list from an SNBT (stringified NBT) string.
+     *
+     * @param snbt The text to parse into NBT
+     * @return The parsed NBT list
+     * @throws IOException If the input string cannot be read or is not a valid SNBT list
+     */
+    @NotNull
+    public static NBTList readList(@NotNull String snbt) throws IOException {
+        return readList(new StringReader(snbt.trim()));
+    }
+
+    /**
+     * Read an SNBT value with an unknown type from the current index of a reader
+     */
+    private static Object read(@NonNull Reader reader) throws IOException {
+        final int firstChar = peekChar(reader);
+
+        switch (firstChar) {
+            case COMPOUND_START:
+                return readCompound(reader);
+
+            case ARRAY_START:
+                return readIterable(reader);
+
+            default:
+                return readLiteral(reader);
+        }
+    }
+
+    /**
+     * Read an SNBT compound from the current index of a reader
+     */
+    private static NBTCompound readCompound(@NonNull Reader reader) throws IOException {
+        NBTCompound compound = new NBTCompound();
+
+        if (readChar(reader) != COMPOUND_START) {
+            throw new NBTParseException("Invalid start of SNBT TAG_Compound");
+        }
+
+        do {
+            skipWhitespace(reader);
+
+            // Check if we've reached the end of the compound.
+            reader.mark(1);
+            if (readChar(reader) == COMPOUND_END) {
+                break;
+            }
+            reader.reset();
+
+            // Read the entry's key/name.
+            String key = readString(reader);
+
+            // Ensure there's a colon between the key and value.
+            skipWhitespace(reader);
+            if (readChar(reader) != ENTRY_VALUE_INDICATOR) {
+                throw new NBTParseException("Invalid value indicator in SNBT TAG_Compound");
+            }
+            skipWhitespace(reader);
+
+            // Read the value and add it to the returned compound.
+            compound.put(key, read(reader));
+            skipWhitespace(reader);
+        } while (readChar(reader) == ENTRY_SEPARATOR);
+
+        return compound;
+    }
+
+    /**
+     * Read an SNBT iterable type from the current index of a reader
+     * <p>
+     * If the type is known to be a list, prefer {@link #readList(Reader)}
+     */
+    private static Object readIterable(@NonNull Reader reader) throws IOException {
+        reader.mark(3);
+
+        if (readChar(reader) != ARRAY_START) {
+            throw new NBTParseException("Invalid start of SNBT iterable");
+        }
+
+        int secondChar = readChar(reader);
+        int thirdChar = readChar(reader);
+
+        final TagType arrayType;
+
+        if (thirdChar == ARRAY_TYPE_INDICATOR) {
+            switch (secondChar) {
+                // TODO: Add constants for these
+                case 'B':
+                    arrayType = TagType.BYTE_ARRAY;
+                    break;
+
+                case 'I':
+                    arrayType = TagType.INT_ARRAY;
+                    break;
+
+                case 'L':
+                    arrayType = TagType.LONG_ARRAY;
+                    break;
+
+                default:
+                    throw new NBTParseException("Unknown SNBT array type");
+            }
+        } else {
+            reader.reset();
+            return readList(reader);
+        }
+
+        List<Object> values = new ArrayList<>();
+        do {
+            skipWhitespace(reader);
+
+            // Check if we've reached the end of the array.
+            reader.mark(1);
+            if (readChar(reader) == ARRAY_END) {
+                break;
+            }
+            reader.reset();
+
+            // Read the next value from the array.
+            Object value = readLiteral(reader);
+
+            // Ensure that the value's type matches that of the array itself.
+            if (arrayType == TagType.BYTE_ARRAY && value instanceof Byte
+                || arrayType == TagType.INT_ARRAY && value instanceof Integer
+                || arrayType == TagType.LONG_ARRAY && value instanceof Long) {
+                values.add(value);
+            } else {
+                throw new NBTParseException("Mismatch between SNBT array and element types");
+            }
+
+            skipWhitespace(reader);
+        } while (readChar(reader) == ENTRY_SEPARATOR);
+
+        // Unwrap the value list into a primitive array.
+        final Object result = Array
+            .newInstance(arrayType.getClazz().getComponentType(), values.size());
+        for (int i = 0; i < values.size(); i++) {
+            Array.set(result, i, values.get(i));
+        }
+        return result;
+    }
+
+    /**
+     * Read an SNBT list from the current index of a reader
+     */
+    private static NBTList readList(@NonNull Reader reader) throws IOException {
+        if (readChar(reader) != ARRAY_START) {
+            throw new NBTParseException("Invalid start of SNBT list");
+        }
+
+        NBTList list = null;
+        do {
+            skipWhitespace(reader);
+
+            // Check if we've reached the end of the list.
+            reader.mark(1);
+            if (readChar(reader) == ARRAY_END) {
+                if (list == null) {
+                    return new NBTList(TagType.END);
+                }
+                break;
+            }
+            reader.reset();
+
+            // Read the next value from the list.
+            Object entry = read(reader);
+
+            if (list == null) {
+                // Create a new list using the tag type of the first entry.
+                list = new NBTList(TagType.fromObject(entry));
+                if (list.getContentType() == TagType.END) {
+                    throw new NBTParseException("SNBT list entry has unrecognized type");
+                }
+                list.add(entry);
+            } else {
+                // Add the entry to the existing list.
+                list.add(entry);
+            }
+        } while (readChar(reader) == ENTRY_SEPARATOR);
+
+        return list;
+    }
+
+    /**
+     * Read any SNBT literal type from the current index of a reader
+     * <p>
+     * If the value is known to be a string, prefer {@link #readString(Reader)}
+     */
+    private static Object readLiteral(@NonNull Reader reader) throws IOException {
+        // Check if the value is in quotes.
+        int firstChar = peekChar(reader);
+        boolean isQuoted = firstChar == STRING_DELIMITER_1 || firstChar == STRING_DELIMITER_2;
+
+        String asString = readString(reader);
+
+        // Always use the string type for text in quotes.
+        if (isQuoted) {
+            return asString;
+        }
+
+        String withoutSuffix = asString.replaceFirst(LITERAL_SUFFIX_PATTERN, "");
+
+        // Try to parse the string as a numeric value.
+        if (asString.matches(INT_PATTERN)) {
+            return Integer.parseInt(withoutSuffix);
+
+        } else if (asString.matches(DOUBLE_PATTERN)) {
+            return Double.parseDouble(withoutSuffix);
+
+        } else if (asString.matches(BYTE_PATTERN)) {
+            return Byte.parseByte(withoutSuffix);
+
+        } else if (asString.matches(SHORT_PATTERN)) {
+            return Short.parseShort(withoutSuffix);
+
+        } else if (asString.matches(LONG_PATTERN)) {
+            return Long.parseLong(withoutSuffix);
+
+        } else if (asString.matches(FLOAT_PATTERN)) {
+            return Float.parseFloat(withoutSuffix);
+
+        } else {
+            // Fall-back to string value.
+            return asString;
+        }
+    }
+
+    /**
+     * Read an SNBT string from the current index of a reader
+     */
+    private static String readString(@NonNull Reader reader) throws IOException {
+        final StringBuilder valueBuilder = new StringBuilder();
+
+        final int firstChar = reader.read();
+        int lastChar;
+
+        // Check if the string is quoted.
+        if (firstChar == STRING_DELIMITER_1 || firstChar == STRING_DELIMITER_2) {
+            boolean isEscaped = false;
+            while ((lastChar = reader.read()) != firstChar || isEscaped) {
+                valueBuilder.append((char) lastChar);
+                isEscaped = lastChar == STRING_ESCAPE;
+            }
+        } else {
+            valueBuilder.append((char) firstChar);
+            reader.mark(1);
+            while (VALID_UNQUOTED_CHARS.indexOf(lastChar = reader.read()) != -1) {
+                valueBuilder.append((char) lastChar);
+                reader.mark(1);
+            }
+            reader.reset();
+        }
+
+        String value = valueBuilder.toString();
+
+        // Only trim whitespace if the string was NOT quoted.
+        if (firstChar != STRING_DELIMITER_1 && firstChar != STRING_DELIMITER_2) {
+            value = value.trim();
+        }
+
+        return value;
+    }
+
+    /**
+     * Skip over zero or more whitespace characters at the current index of a reader
+     */
+    private static void skipWhitespace(@NonNull Reader reader) throws IOException {
+        do {
+            reader.mark(1);
+        } while (Character.isWhitespace(reader.read()));
+        reader.reset();
+    }
+
+    /**
+     * Read a single character from the provided reader without increasing its index
+     */
+    private static int peekChar(@NonNull Reader reader) throws IOException {
+        reader.mark(1);
+        int value = reader.read();
+        reader.reset();
+        if (value == -1) {
+            throw new IOException("Unexpected end of SNBT string");
+        }
+        return value;
+    }
+
+    /**
+     * Read a single character from the provided reader.
+     * <p>
+     * To read without increasing the reader's index, see {@link #peekChar(Reader)}.
+     */
+    private static int readChar(@NonNull Reader reader) throws IOException {
+        int value = reader.read();
+        if (value == -1) {
+            throw new IOException("Unexpected end of SNBT string");
+        }
+        return value;
+    }
+
+    private SNBTReader() {
+        // Prevent instantiation of this class
+    }
+}

--- a/src/main/java/me/nullicorn/nedit/exception/NBTParseException.java
+++ b/src/main/java/me/nullicorn/nedit/exception/NBTParseException.java
@@ -1,50 +1,24 @@
 package me.nullicorn.nedit.exception;
 
-import java.io.IOException;
-import java.security.PrivilegedActionException;
-
 /**
  * @author Nullicorn
  */
-public class NBTParseException extends IOException {
+public class NBTParseException extends NBTSerializationException {
 
     private static final String DEFAULT_MESSAGE = "Unable to parse NBT data from stream";
 
-    /**
-     * Constructs a new exception with {@code null} as its detail message. The cause is not initialized, and may subsequently be initialized by a call to {@link #initCause}.
-     */
     public NBTParseException() {
         this(DEFAULT_MESSAGE);
     }
 
-    /**
-     * Constructs a new exception with the specified detail message.  The cause is not initialized, and may subsequently be initialized by a call to {@link #initCause}.
-     *
-     * @param message the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
-     */
     public NBTParseException(String message) {
         super(message);
     }
 
-    /**
-     * Constructs a new exception with the specified detail message and cause.  <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically incorporated in this
-     * exception's detail message.
-     *
-     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
-     * @param cause   the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown.)
-     * @since 1.4
-     */
     public NBTParseException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    /**
-     * Constructs a new exception with the specified cause and a detail message of <tt>(cause==null ? null : cause.toString())</tt> (which typically contains the class and detail message of
-     * <tt>cause</tt>). This constructor is useful for exceptions that are little more than wrappers for other throwables (for example, {@link PrivilegedActionException}).
-     *
-     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or unknown.)
-     * @since 1.4
-     */
     public NBTParseException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/me/nullicorn/nedit/exception/NBTSerializationException.java
+++ b/src/main/java/me/nullicorn/nedit/exception/NBTSerializationException.java
@@ -1,0 +1,24 @@
+package me.nullicorn.nedit.exception;
+
+import java.io.IOException;
+
+/**
+ * @author Nullicorn
+ */
+public class NBTSerializationException extends IOException {
+
+    public NBTSerializationException() {
+    }
+
+    public NBTSerializationException(String message) {
+        super(message);
+    }
+
+    public NBTSerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NBTSerializationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
@@ -3,6 +3,7 @@ package me.nullicorn.nedit.type;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -379,23 +380,32 @@ public class NBTCompound extends HashMap<String, Object> {
                 if (!(oValue == null && c.containsKey(key))) {
                     return false;
                 }
-            } else {
-                if (value instanceof byte[] && oValue instanceof byte[]
-                    && Arrays.equals((byte[]) value, (byte[]) oValue)) {
-                    continue;
-                } else if (value instanceof int[] && oValue instanceof int[]
-                    && Arrays.equals((int[]) value, (int[]) oValue)) {
-                    continue;
-                } else if (value instanceof long[] && oValue instanceof long[]
-                    && Arrays.equals((long[]) value, (long[]) oValue)) {
-                    continue;
-                } else if (value.equals(oValue)) {
-                    continue;
-                } else {
-                    return false;
-                }
+            } else if (!Objects.deepEquals(value, oValue)) {
+                return false;
             }
         }
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 0;
+        for (Entry<String, Object> entry : entrySet()) {
+            final Object value = entry.getValue();
+            final int valHash;
+
+            if (value instanceof byte[]) {
+                valHash = Arrays.hashCode((byte[]) value);
+            } else if (value instanceof int[]) {
+                valHash = Arrays.hashCode((int[]) value);
+            } else if (value instanceof long[]) {
+                valHash = Arrays.hashCode((long[]) value);
+            } else {
+                valHash = value.hashCode();
+            }
+
+            h += Objects.hashCode(entry.getKey()) ^ valHash;
+        }
+        return h;
     }
 }

--- a/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
@@ -1,5 +1,6 @@
 package me.nullicorn.nedit.type;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.jetbrains.annotations.Nullable;
@@ -24,7 +25,8 @@ public class NBTCompound extends HashMap<String, Object> {
     /**
      * @param key          A dot-separated path to the desired field
      * @param defaultValue The value to return if the field does not exist
-     * @return The floating-point number at the desired path, or the default value if it does not exist
+     * @return The floating-point number at the desired path, or the default value if it does not
+     * exist
      * @see #get(String)
      */
     public float getFloat(String key, float defaultValue) {
@@ -351,5 +353,49 @@ public class NBTCompound extends HashMap<String, Object> {
         }
         sb.append("]");
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof NBTCompound)) {
+            return false;
+        }
+        NBTCompound c = (NBTCompound) o;
+
+        if (c.size() != this.size()) {
+            return false;
+        }
+
+        for (Entry<String, Object> entry : entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            Object oValue = c.get(key);
+
+            if (value == null) {
+                if (!(oValue == null && c.containsKey(key))) {
+                    return false;
+                }
+            } else {
+                if (value instanceof byte[] && oValue instanceof byte[]
+                    && Arrays.equals((byte[]) value, (byte[]) oValue)) {
+                    continue;
+                } else if (value instanceof int[] && oValue instanceof int[]
+                    && Arrays.equals((int[]) value, (int[]) oValue)) {
+                    continue;
+                } else if (value instanceof long[] && oValue instanceof long[]
+                    && Arrays.equals((long[]) value, (long[]) oValue)) {
+                    continue;
+                } else if (value.equals(oValue)) {
+                    continue;
+                } else {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
- Added support for reading SNBT (aka "Mojangson") strings
  - This is the format Minecraft uses for NBT data in commands
- NBTReader and NBTInputStream now read from the root tag instead of the implicit one
  - This means most initial paths no longer need to be prefixed with a dot (e.g. `.Level.xPos` --> `Level.xPos`)
- Added `hashCode()` and `equals()` support for NBTCompound
- Fix extra TAG_End added to data by the NBTOutputStream