### PR TITLE
Update v1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.nullicorn</groupId>
     <artifactId>Nedit</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTOutputStream.java
@@ -28,9 +28,16 @@ public class NBTOutputStream extends DataOutputStream {
      * @throws IOException If the compound could not be written
      */
     public void writeFully(NBTCompound compound) throws IOException {
-        writeCompound(compound, false);
-        if (out instanceof GZIPOutputStream) {
-            ((GZIPOutputStream) out).finish();
+        if (compound == null) {
+            writeTagType(TagType.END);
+        } else {
+            writeTagType(TagType.COMPOUND);
+            writeString("");
+            writeCompound(compound, false);
+
+            if (out instanceof GZIPOutputStream) {
+                ((GZIPOutputStream) out).finish();
+            }
         }
     }
 

--- a/src/main/java/me/nullicorn/nedit/NBTWriter.java
+++ b/src/main/java/me/nullicorn/nedit/NBTWriter.java
@@ -83,7 +83,8 @@ public final class NBTWriter {
      * @param data           NBT compound to serialize
      * @param outputStream   Output stream to write the serialized NBT to
      * @param useCompression If true, the serialized data will be gzipped
-     * @throws IOException If the NBT data could not be serialized or the outpt stream could not be written to
+     * @throws IOException If the NBT data could not be serialized or the output stream could not be
+     *                     written to
      */
     public static void write(@NotNull NBTCompound data, @NotNull OutputStream outputStream, boolean useCompression) throws IOException {
         try (NBTOutputStream out = new NBTOutputStream(outputStream, useCompression)) {

--- a/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
+++ b/src/main/java/me/nullicorn/nedit/type/NBTCompound.java
@@ -14,6 +14,14 @@ import org.jetbrains.annotations.Nullable;
 public class NBTCompound extends HashMap<String, Object> {
 
     /**
+     * @return Whether or not this compound contains a tag whose {@code name} and {@code type} match
+     * those provided
+     */
+    public boolean containsTag(String key, TagType type) {
+        return TagType.fromObject(get(key)) == type;
+    }
+
+    /**
      * @param key          A dot-separated path to the desired field
      * @param defaultValue The value to return if the field does not exist
      * @return The double at the desired path, or the default value if it does not exist


### PR DESCRIPTION
Two quick changes-
- Wrap `NBTOutputStream` (and subsequently `NBTWriter`) output in an unnamed compound
  - This change is to match the new behavior of `NBTInputStream`
- Add `containsTag(String, TagType)` to `NBTCompound`
  - Provides the same functionality as `contains(String)` while also checking that the matching tag is the desired type