### PR TITLE
Update v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,15 @@ Nedit is a simple, lightweight NBT parsing library with support for plain, gzipp
 Nedit can be added to most major build-automation tools using JitPack. See the instructions [here](https://jitpack.io/#TheNullicorn/Nedit) for more info.
 
 ## Usage
-To parse NBT data, Nedit provides you with the NBTReader class, which can be used like so:
+
+
+NBT compounds are essentially just maps of strings to values. Because of this, NBTCompound class extends `java.util.Map`, and you can use any normal mapping functions to retireve and modify data within the compound.
+
+NBTCompound also provides a layer of null-safety when accessing deeply-nested fields whose parent objects may be null. Accessors for primitives (`int`, `boolean`, `float`, etc) and `String`s also accept a default value in case the requested field isn't found.
+
+**Example (extending the previous one):**
 ```java
-NBTReader reader = new NBTReader("CgALaGVsbG8gd29ybGQIAARuYW1lAAlCYW5hbnJhbWEA");
-NBTCompound result = reader.read();
-System.out.println("Result: " + result);
-
-// Result: {hello world:{name:"Bananrama"}}
-```
-
-NBT compounds are essentially maps. Because of this, NBTCompound class extends java.util.Map and you can use any normal map functions to retireve and modify data within the compound.
-
-NBTCompound also provides some helper methods for retrieving deeply nested fields without having to repeatedly check for null. These methods also allow you to provide a default value in case the field is null or does not exist.
-
-**Example (added onto the previous one):**
-```java
-System.out.println("Name: " + result.getString("hello world.name", "Not Found"));
+System.out.println("Name: " + result.getString("hello world.name", "(Not Found!)"));
 
 // Name: Bananrama
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Nedit is a simple, lightweight NBT parsing library with support for plain, gzipp
 Nedit can be added to most major build-automation tools using JitPack. See the instructions [here](https://jitpack.io/#TheNullicorn/Nedit) for more info.
 
 ## Usage
+To parse NBT data, Nedit provides you with the NBTReader class, which can be used like so:
+```java
+NBTCompound result = NBTReader.readBase64("CgALaGVsbG8gd29ybGQIAARuYW1lAAlCYW5hbnJhbWEA");
+System.out.println("Full Result:  " + result);
 
+// Full Result:  {hello world:{name:"Bananrama"}}
+```
 
 NBT compounds are essentially just maps of strings to values. Because of this, NBTCompound class extends `java.util.Map`, and you can use any normal mapping functions to retireve and modify data within the compound.
 

--- a/src/main/java/me/nullicorn/nedit/NBTReader.java
+++ b/src/main/java/me/nullicorn/nedit/NBTReader.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.util.Base64;
 import lombok.NonNull;
 import me.nullicorn.nedit.type.NBTCompound;
+import me.nullicorn.nedit.type.TagType;
 
 /**
  * A utility class for reading NBT data from various sources
@@ -23,10 +24,25 @@ public final class NBTReader {
      * @param base64 Base64-encoded string containing NBT data (may be gzipped)
      * @return The parsed compound
      * @throws IOException If the data could not be read properly
-     * @see #read(InputStream)
      */
     public static NBTCompound readBase64(@NonNull String base64) throws IOException {
-        return read(new ByteArrayInputStream(Base64.getDecoder().decode(base64)));
+        return readBase64(base64, false, false);
+    }
+
+    /**
+     * Same as {@link #readBase64(String)}, but with additional control over the interning of tag
+     * names and values
+     *
+     * @param internNames  Whether or not tag names inside of compounds will be interned
+     * @param internValues Whether or not {@link TagType#STRING} values inside compounds and lists
+     *                     will be interned
+     * @see #readBase64(String)
+     * @see String#intern()
+     * @see NBTInputStream#NBTInputStream(InputStream, boolean, boolean)
+     */
+    public static NBTCompound readBase64(@NonNull String base64, boolean internNames, boolean internValues) throws IOException {
+        ByteArrayInputStream b64In = new ByteArrayInputStream(Base64.getDecoder().decode(base64));
+        return read(b64In, internNames, internValues);
     }
 
     /**
@@ -37,10 +53,25 @@ public final class NBTReader {
      * @throws IOException If the file or its contents could not be read properly
      */
     public static NBTCompound readFile(@NonNull File nbtFile) throws IOException {
+        return readFile(nbtFile, false, false);
+    }
+
+    /**
+     * Same as {@link #readFile(File)}, but with additional control over the interning of tag names
+     * and values
+     *
+     * @param internNames  Whether or not tag names inside of compounds will be interned
+     * @param internValues Whether or not {@link TagType#STRING} values inside compounds and lists
+     *                     will be interned
+     * @see #read(InputStream)
+     * @see String#intern()
+     * @see NBTInputStream#NBTInputStream(InputStream, boolean, boolean)
+     */
+    public static NBTCompound readFile(@NonNull File nbtFile, boolean internNames, boolean internValues) throws IOException {
         if (!nbtFile.exists() || !nbtFile.isFile() || !nbtFile.canRead()) {
             throw new FileNotFoundException("NBT file not found or unable to be read");
         }
-        return read(new FileInputStream(nbtFile));
+        return read(new FileInputStream(nbtFile), internNames, internValues);
     }
 
     /**
@@ -51,8 +82,23 @@ public final class NBTReader {
      * @throws IOException If the data could not be read properly
      */
     public static NBTCompound read(@NonNull InputStream inputStream) throws IOException {
+        return read(inputStream, false, false);
+    }
+
+    /**
+     * Same as {@link #read(InputStream)}, but with additional control over the interning of tag
+     * names and values
+     *
+     * @param internNames  Whether or not tag names inside of compounds will be interned
+     * @param internValues Whether or not {@link TagType#STRING} values inside compounds and lists
+     *                     will be interned
+     * @see #read(InputStream)
+     * @see String#intern()
+     * @see NBTInputStream#NBTInputStream(InputStream, boolean, boolean)
+     */
+    public static NBTCompound read(@NonNull InputStream inputStream, boolean internNames, boolean internValues) throws IOException {
         try (InputStream nbtIn = inputStream) {
-            return new NBTInputStream(nbtIn).readFully();
+            return new NBTInputStream(nbtIn, internNames, internValues).readFully();
         }
     }
 


### PR DESCRIPTION
Minor optimization:
- Added support for interning tag names & values.
  - Methods that now support interning have done so via overloading, and the original methods will have interning __disabled by default__.
  - When deserializing *lots* of NBT data that follows the same structure, or uses similar string values, this can help save a significant amount of memory.
  - If deserialization is infrequent and with small data, there should be little-to-no difference in performance or memory consumption.