### PR TITLE
Fix increment on bitOffset in readIntArray

### DIFF
--- a/src/main/java/me/nullicorn/nedit/NBTInputStream.java
+++ b/src/main/java/me/nullicorn/nedit/NBTInputStream.java
@@ -199,7 +199,7 @@ public class NBTInputStream extends DataInputStream {
         for (int i = 0; i < length; i++, byteIndex += 4) {
             int element = 0;
             int bitOffset = 24;
-            for (int b = 0; b < 4; b++, bitOffset -= 4) {
+            for (int b = 0; b < 4; b++, bitOffset -= 8) {
                 element |= (bytes[byteIndex + b] & 0xFF) << bitOffset;
             }
             intArray[i] = element;


### PR DESCRIPTION
bitOffset should be decremented by 8 bits (a whole byte) instead of 4 bits (half a byte) in readIntArray.